### PR TITLE
GCB-198: Add empty state ViewModel + header and subheader.

### DIFF
--- a/GrandCentralBoard/Widgets/Harvest/HarvestWidget.swift
+++ b/GrandCentralBoard/Widgets/Harvest/HarvestWidget.swift
@@ -25,20 +25,27 @@ final class HarvestWidget : Widget {
     }
 
     func update(source: UpdatingSource) {
-        guard let source = source as? HarvestSource else { return }
 
-        source.read({ result in
-            self.updateViewWithViewModel(result)
-        })
+        guard let source = source as? HarvestSource else {
+            fatalError("Expected `source` as instance of `HarvestSource`.")
+        }
+
+        source.read { [weak self] result in
+            self?.updateViewWithResult(result)
+        }
     }
 
-    func updateViewWithViewModel(viewModel: HarvestSource.ResultType) {
+    func updateViewWithResult(result: HarvestSource.ResultType) {
 
         // TODO: Remove fake ViewModels.
-        let items = [AreaBarItemViewModel(proportionalWidth: 0.5, proportionalHeight: 0.2, color: UIColor.lipstick(), valueLabelMode: .Left(text: "123")), AreaBarItemViewModel(proportionalWidth: 0.25, proportionalHeight: 0.5, color: UIColor.aquaMarine(), valueLabelMode: .Hidden), AreaBarItemViewModel(proportionalWidth: 0.25, proportionalHeight: 1, color: UIColor.almostWhite(), valueLabelMode: .Right(text: "222"))]
+        let items = [AreaBarItemViewModel(proportionalWidth: 0.5, proportionalHeight: 0.2, color: UIColor.lipstick(), valueLabelMode: .VisibleLabelLeft(text: "123")), AreaBarItemViewModel(proportionalWidth: 0.25, proportionalHeight: 0.5, color: UIColor.aquaMarine(), valueLabelMode: .VisibleWithHiddenLabel), AreaBarItemViewModel(proportionalWidth: 0.25, proportionalHeight: 1, color: UIColor.almostWhite(), valueLabelMode: .VisibleLabelRight(text: "222"))]
 
-        let model = AreaBarChartViewModel(barItems: items, horizontalAxisStops: 20, horizontalAxisLabelText: "people billing:", hotizontalAxisCountLabelText: "666")
+        let model = AreaBarChartViewModel(barItems: items, horizontalAxisStops: 20, horizontalAxisLabelText: "people billing:", hotizontalAxisCountLabelText: "666", centerText: nil, headerText: "HARVEST BURN REPORT", subheaderText: "Monday 28.03.2016")
 
         widgetView.render(model)
+
+        // Why another render? To check if view renders the view model after the previous one.
+        // TODO: Remove!
+        widgetView.render(AreaBarChartViewModel.emptyViewModel(header: "HARVEST BURN REPORT", subheader: "Monday 28.03.2016"))
     }
 }

--- a/GrandCentralBoard/Widgets/Harvest/View/AreaBarChartView.swift
+++ b/GrandCentralBoard/Widgets/Harvest/View/AreaBarChartView.swift
@@ -95,13 +95,17 @@ final class AreaBarChartView : UIView, ViewModelRendering {
     private func handleTransitionFromState(state: RenderingState<ViewModel>, toState: RenderingState<ViewModel>) {
         switch (state, toState) {
         case (_, .Rendering(let viewModel)):
-            activityIndicatorView.stopAnimating()
-            configureBarsWithViewModel(viewModel)
-            configureLabelsWithViewModel(viewModel)
-            configureAxisWithViewModel(viewModel)
+            configureWithViewModel(viewModel)
         default:
             break
         }
+    }
+
+    private func configureWithViewModel(viewModel: AreaBarChartViewModel) {
+        activityIndicatorView.stopAnimating()
+        configureBarsWithViewModel(viewModel)
+        configureLabelsWithViewModel(viewModel)
+        configureAxisWithViewModel(viewModel)
     }
 
     // MARK: -

--- a/GrandCentralBoard/Widgets/Harvest/View/AreaBarChartView.swift
+++ b/GrandCentralBoard/Widgets/Harvest/View/AreaBarChartView.swift
@@ -23,6 +23,11 @@ final class AreaBarHorizontalAxisStackView : UIStackView {
 
     func drawAxisWithViewModel(viewModel: AreaBarChartViewModel) {
 
+        arrangedSubviews.forEach { view in
+            removeArrangedSubview(view)
+            view.removeFromSuperview()
+        }
+
         let stops = viewModel.horizontalAxisStops
 
         for stop in 0...stops {
@@ -56,9 +61,14 @@ final class AreaBarChartView : UIView, ViewModelRendering {
 
     @IBOutlet private var barStackView: AreaBarStackView!
     @IBOutlet private var axisStackView: AreaBarHorizontalAxisStackView!
-
+    @IBOutlet private var activityIndicatorView: UIActivityIndicatorView!
+    @IBOutlet private var centerLabel: UILabel!
+    @IBOutlet private var headerLabel: UILabel!
+    @IBOutlet private var subheaderLabel: UILabel!
     @IBOutlet private var horizontalAxisLabel: UILabel!
     @IBOutlet private var hotizontalAxisCountLabel: UILabel!
+
+    private var dashedLinesWithLabels: [UIView] = []
 
     override func awakeFromNib() {
         super.awakeFromNib()
@@ -85,6 +95,7 @@ final class AreaBarChartView : UIView, ViewModelRendering {
     private func handleTransitionFromState(state: RenderingState<ViewModel>, toState: RenderingState<ViewModel>) {
         switch (state, toState) {
         case (_, .Rendering(let viewModel)):
+            activityIndicatorView.stopAnimating()
             configureBarsWithViewModel(viewModel)
             configureLabelsWithViewModel(viewModel)
             configureAxisWithViewModel(viewModel)
@@ -98,9 +109,22 @@ final class AreaBarChartView : UIView, ViewModelRendering {
     private func configureLabelsWithViewModel(viewModel: AreaBarChartViewModel) {
         horizontalAxisLabel.text = viewModel.horizontalAxisLabelText
         hotizontalAxisCountLabel.text = viewModel.hotizontalAxisCountLabelText
+        centerLabel.text = viewModel.centerText
+        headerLabel.text = viewModel.headerText
+        subheaderLabel.text = viewModel.subheaderText
     }
 
     private func configureBarsWithViewModel(viewModel: AreaBarChartViewModel) {
+
+        barStackView.arrangedSubviews.forEach { view in
+            barStackView.removeArrangedSubview(view)
+            view.removeFromSuperview()
+        }
+
+        dashedLinesWithLabels.forEach { view in
+            view.removeFromSuperview()
+        }
+
         viewModel.barItems.forEach { itemViewModel in
             let barView = barStackView.addBarWithItemViewModel(itemViewModel)
             addLineWithLabelToBarView(barView, withViewModel: itemViewModel)
@@ -113,6 +137,7 @@ final class AreaBarChartView : UIView, ViewModelRendering {
         let dashedLine = AreaBarDashedLineWithLabel.fromNib()
         dashedLine.configureWithViewModel(viewModel)
         addSubview(dashedLine)
+        dashedLinesWithLabels.append(dashedLine)
         setUpConstraintsOfDashedLine(dashedLine, toBar: barView)
     }
 

--- a/GrandCentralBoard/Widgets/Harvest/View/AreaBarChartView.xib
+++ b/GrandCentralBoard/Widgets/Harvest/View/AreaBarChartView.xib
@@ -4,7 +4,12 @@
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
     </dependencies>
     <customFonts key="customFonts">
+        <mutableArray key="SF-UI-Text-Bold.otf">
+            <string>SFUIText-Bold</string>
+        </mutableArray>
         <mutableArray key="SF-UI-Text-Regular.otf">
+            <string>SFUIText-Regular</string>
+            <string>SFUIText-Regular</string>
             <string>SFUIText-Regular</string>
         </mutableArray>
         <mutableArray key="SF-UI-Text-Semibold.otf">
@@ -19,31 +24,58 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <stackView contentMode="scaleToFill" distribution="equalSpacing" alignment="bottom" translatesAutoresizingMaskIntoConstraints="NO" id="4gQ-GJ-9Xa" customClass="AreaBarStackView" customModule="GrandCentralBoard" customModuleProvider="target">
-                    <rect key="frame" x="100" y="174" width="440" height="150"/>
+                    <rect key="frame" x="100" y="146" width="440" height="160"/>
                 </stackView>
                 <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="67T-0x-MWe" customClass="AreaBarHorizontalAxisStackView" customModule="GrandCentralBoard" customModuleProvider="target">
-                    <rect key="frame" x="100" y="324" width="440" height="32"/>
+                    <rect key="frame" x="100" y="306" width="440" height="32"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="32" id="mMq-2y-IJq"/>
                     </constraints>
                 </stackView>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="people billing:" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UzJ-7H-2ow">
-                    <rect key="frame" x="457" y="333" width="80" height="15"/>
+                    <rect key="frame" x="457" y="315" width="80" height="15"/>
                     <fontDescription key="fontDescription" name="SFUIText-Regular" family="SF UI Text" pointSize="12"/>
                     <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="calibratedRGB"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="18" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mBP-RG-2vV">
-                    <rect key="frame" x="545" y="329" width="22" height="22"/>
+                    <rect key="frame" x="545" y="311" width="22" height="22"/>
                     <fontDescription key="fontDescription" name="SFUIText-Semibold" family="SF UI Text" pointSize="18"/>
+                    <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="calibratedRGB"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" animating="YES" style="white" translatesAutoresizingMaskIntoConstraints="NO" id="fs4-Yy-wpp">
+                    <rect key="frame" x="300" y="230" width="40" height="40"/>
+                </activityIndicatorView>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8K4-6B-X3K">
+                    <rect key="frame" x="320" y="250" width="0.0" height="0.0"/>
+                    <fontDescription key="fontDescription" name="SFUIText-Regular" family="SF UI Text" pointSize="24"/>
+                    <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="HARVEST BURN REPORT" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8ZG-zW-EJz">
+                    <rect key="frame" x="208" y="32" width="224" height="22"/>
+                    <fontDescription key="fontDescription" name="SFUIText-Bold" family="SF UI Text" pointSize="18"/>
+                    <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="calibratedRGB"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Monday 28.03.2016" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1T5-KP-Oc5">
+                    <rect key="frame" x="255" y="66" width="131" height="17"/>
+                    <fontDescription key="fontDescription" name="SFUIText-Regular" family="SF UI Text" pointSize="14"/>
                     <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="calibratedRGB"/>
                     <nil key="highlightedColor"/>
                 </label>
             </subviews>
             <color key="backgroundColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
             <constraints>
+                <constraint firstItem="fs4-Yy-wpp" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="08z-If-A7a"/>
+                <constraint firstItem="8ZG-zW-EJz" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="09a-1H-f1Y"/>
+                <constraint firstItem="8ZG-zW-EJz" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="32" id="CJZ-fx-tXH"/>
                 <constraint firstItem="4gQ-GJ-9Xa" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="100" id="Dgo-jS-HXz"/>
-                <constraint firstItem="4gQ-GJ-9Xa" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="174" id="Dng-Fe-UXN"/>
+                <constraint firstItem="4gQ-GJ-9Xa" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="146" id="Dng-Fe-UXN"/>
+                <constraint firstItem="8K4-6B-X3K" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="GNu-nz-G5R"/>
+                <constraint firstItem="fs4-Yy-wpp" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="centerY" constant="-20" id="IHP-X2-plw"/>
+                <constraint firstItem="1T5-KP-Oc5" firstAttribute="top" secondItem="8ZG-zW-EJz" secondAttribute="bottom" constant="12" id="Ty2-yu-LNb"/>
                 <constraint firstAttribute="trailing" secondItem="67T-0x-MWe" secondAttribute="trailing" constant="100" id="VWN-am-yr1"/>
                 <constraint firstItem="UzJ-7H-2ow" firstAttribute="trailing" secondItem="67T-0x-MWe" secondAttribute="trailing" constant="-3" id="XFa-Lh-hfv"/>
                 <constraint firstItem="mBP-RG-2vV" firstAttribute="leading" secondItem="UzJ-7H-2ow" secondAttribute="trailing" constant="8" id="aaP-cA-8wk"/>
@@ -52,15 +84,21 @@
                 <constraint firstAttribute="trailing" secondItem="4gQ-GJ-9Xa" secondAttribute="trailing" constant="100" id="duh-0r-CN7"/>
                 <constraint firstItem="67T-0x-MWe" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="100" id="ghU-Sj-dc4"/>
                 <constraint firstItem="UzJ-7H-2ow" firstAttribute="centerY" secondItem="67T-0x-MWe" secondAttribute="centerY" id="nMQ-0g-SVr"/>
-                <constraint firstAttribute="bottom" secondItem="4gQ-GJ-9Xa" secondAttribute="bottom" constant="216" id="vEF-Hn-tPW"/>
+                <constraint firstItem="1T5-KP-Oc5" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="nre-uD-Tfu"/>
+                <constraint firstItem="8K4-6B-X3K" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="centerY" constant="-20" id="oCQ-Ez-nbj"/>
+                <constraint firstAttribute="bottom" secondItem="4gQ-GJ-9Xa" secondAttribute="bottom" constant="234" id="vEF-Hn-tPW"/>
             </constraints>
             <nil key="simulatedTopBarMetrics"/>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <connections>
+                <outlet property="activityIndicatorView" destination="fs4-Yy-wpp" id="9EN-OS-Rtk"/>
                 <outlet property="axisStackView" destination="67T-0x-MWe" id="17X-1M-JXv"/>
                 <outlet property="barStackView" destination="4gQ-GJ-9Xa" id="NOW-L6-8Ur"/>
+                <outlet property="centerLabel" destination="8K4-6B-X3K" id="FA0-WO-sek"/>
+                <outlet property="headerLabel" destination="8ZG-zW-EJz" id="Zuy-TR-poK"/>
                 <outlet property="horizontalAxisLabel" destination="UzJ-7H-2ow" id="j5C-TU-Oqg"/>
                 <outlet property="hotizontalAxisCountLabel" destination="mBP-RG-2vV" id="hYq-Yl-oHJ"/>
+                <outlet property="subheaderLabel" destination="1T5-KP-Oc5" id="lk3-eD-f79"/>
             </connections>
         </view>
     </objects>

--- a/GrandCentralBoard/Widgets/Harvest/View/AreaBarChartViewModel.swift
+++ b/GrandCentralBoard/Widgets/Harvest/View/AreaBarChartViewModel.swift
@@ -8,8 +8,9 @@ import UIKit
 
 enum AreaBarItemValueLabelDisplayMode {
     case Hidden
-    case Left(text: String)
-    case Right(text: String)
+    case VisibleWithHiddenLabel
+    case VisibleLabelLeft(text: String)
+    case VisibleLabelRight(text: String)
 }
 
 struct AreaBarItemViewModel {
@@ -24,4 +25,16 @@ struct AreaBarChartViewModel {
     let horizontalAxisStops: Int
     let horizontalAxisLabelText: String
     let hotizontalAxisCountLabelText: String
+    let centerText: String?
+    let headerText: String?
+    let subheaderText: String?
+
+    static func emptyViewModel(header header: String? = nil, subheader: String? = nil) -> AreaBarChartViewModel {
+        let items = [
+            AreaBarItemViewModel(proportionalWidth: 0.333, proportionalHeight: 0.05, color: UIColor.lipstick(), valueLabelMode: .Hidden),
+            AreaBarItemViewModel(proportionalWidth: 0.333, proportionalHeight: 0.05, color: UIColor.aquaMarine(), valueLabelMode: .Hidden),
+            AreaBarItemViewModel(proportionalWidth: 0.333, proportionalHeight: 0.05, color: UIColor.almostWhite(), valueLabelMode: .Hidden)]
+
+        return AreaBarChartViewModel(barItems: items, horizontalAxisStops: 20, horizontalAxisLabelText: "people billing:", hotizontalAxisCountLabelText: "0", centerText: "We didn't work yesterday", headerText: header, subheaderText: subheader)
+    }
 }

--- a/GrandCentralBoard/Widgets/Harvest/View/AreaBarDashedLineWithLabel.swift
+++ b/GrandCentralBoard/Widgets/Harvest/View/AreaBarDashedLineWithLabel.swift
@@ -19,14 +19,19 @@ final class AreaBarDashedLineWithLabel : UIView {
 
         switch viewModel.valueLabelMode {
         case .Hidden:
+            hidden = true
+        case .VisibleWithHiddenLabel:
+            hidden = false
             valueLabelLeft.hidden = true
             valueLabelRight.hidden = true
-        case .Left(let text):
+        case .VisibleLabelLeft(let text):
+            hidden = false
             valueLabelLeft.textColor = color
             valueLabelLeft.hidden = false
             valueLabelLeft.text = text
             valueLabelRight.hidden = true
-        case .Right(let text):
+        case .VisibleLabelRight(let text):
+            hidden = false
             valueLabelRight.textColor = color
             valueLabelRight.hidden = false
             valueLabelRight.text = text

--- a/GrandCentralBoard/Widgets/Image/View/ImageWidgetView.xib
+++ b/GrandCentralBoard/Widgets/Image/View/ImageWidgetView.xib
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder.AppleTV.XIB" version="3.0" toolsVersion="9532" systemVersion="15D21" targetRuntime="AppleTV" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder.AppleTV.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="AppleTV" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9530"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
@@ -12,13 +12,14 @@
             <subviews>
                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="jyM-la-gmf">
                     <rect key="frame" x="0.0" y="0.0" width="640" height="540"/>
+                    <color key="backgroundColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
                 </imageView>
-                <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" animating="YES" style="whiteLarge" translatesAutoresizingMaskIntoConstraints="NO" id="kKg-XI-PTx">
-                    <rect key="frame" x="288" y="238" width="64" height="64"/>
-                    <color key="color" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
+                <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" animating="YES" style="white" translatesAutoresizingMaskIntoConstraints="NO" id="kKg-XI-PTx">
+                    <rect key="frame" x="300" y="250" width="40" height="40"/>
+                    <color key="color" white="1" alpha="1" colorSpace="calibratedWhite"/>
                 </activityIndicatorView>
             </subviews>
-            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+            <color key="backgroundColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
             <constraints>
                 <constraint firstAttribute="bottom" secondItem="jyM-la-gmf" secondAttribute="bottom" id="4QN-Do-CYW"/>
                 <constraint firstItem="kKg-XI-PTx" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="centerY" id="5Dy-4z-6Bo"/>


### PR DESCRIPTION
🚚  https://macoscope.atlassian.net/browse/GCB-198

Bonus:
- Changed ImageWidget background from flashing white to proper black.
- Improved handling of second render.
- After consulting with Dawid - added Header and Subheader label instead of dashed line in empty mode.

![simulator screen shot 14 04 2016 19 58 47](https://cloud.githubusercontent.com/assets/3382607/14538341/9ac848a8-027b-11e6-8b88-cde2f24057bd.png)
