### PR TITLE
Return correct value when executing travis-script

### DIFF
--- a/GrandCentralBoardTests/CalendarDataProviderTests.swift
+++ b/GrandCentralBoardTests/CalendarDataProviderTests.swift
@@ -21,7 +21,7 @@ private let eventsDictionary = ["kind": "calendar#events", "items" :
 
 class TestAPIDataProvider : APIDataProviding {
 
-    func request(method: GrandCentralBoard.Method, url: NSURL, parameters: [String : AnyObject]?, completion: Result<AnyObject, APIDataError> -> Void) {
+    func request(method: GrandCentralBoard.Method, url: NSURL, parameters: [String : AnyObject]?, encoding: ParameterEncoding, completion: Result<AnyObject, APIDataError> -> Void) {
         let urlString = url.URLString
         if urlString.hasSuffix("/events") {
             completion(.Success(eventsDictionary))

--- a/GrandCentralBoardTests/GoogleAnalyticsDataProviderTests.swift
+++ b/GrandCentralBoardTests/GoogleAnalyticsDataProviderTests.swift
@@ -26,7 +26,7 @@ private let responseData = [ "reports" : [ report ] ]
 
 private class TestDataProvider : APIDataProviding {
     func request(method: GrandCentralBoard.Method, url: NSURL, parameters: [String: AnyObject]?,
-                 completion: ResultType<AnyObject, APIDataError>.result -> Void) {
+                 encoding: ParameterEncoding, completion: ResultType<AnyObject, APIDataError>.result -> Void) {
 
         completion(.Success(responseData))
     }

--- a/scripts/travis-script.sh
+++ b/scripts/travis-script.sh
@@ -2,7 +2,7 @@
 
 function run_tests
 {
-  xcodebuild test -workspace GrandCentralBoard.xcworkspace -scheme GrandCentralBoard -sdk appletvsimulator9.2 -configuration 'Debug' ONLY_ACTIVE_ARCH=NO | xcpretty -f `xcpretty-travis-formatter`
+  xcodebuild test -workspace GrandCentralBoard.xcworkspace -scheme GrandCentralBoard -sdk appletvsimulator9.2 -configuration 'Debug' ONLY_ACTIVE_ARCH=NO | xcpretty -c -f `xcpretty-travis-formatter`; exit ${PIPESTATUS[0]}
 }
 
 if [[ "$TRAVIS_PULL_REQUEST" != "false" ]] || [[ "$TRAVIS_BRANCH" == "mvp" ]]; then

--- a/scripts/travis-script.sh
+++ b/scripts/travis-script.sh
@@ -2,7 +2,8 @@
 
 function run_tests
 {
-  xcodebuild test -workspace GrandCentralBoard.xcworkspace -scheme GrandCentralBoard -sdk appletvsimulator9.2 -configuration 'Debug' ONLY_ACTIVE_ARCH=NO | xcpretty -c -f `xcpretty-travis-formatter`; exit ${PIPESTATUS[0]}
+	# read https://github.com/supermarin/xcpretty#usage to get more details about the way xcpretty is used
+  	xcodebuild test -workspace GrandCentralBoard.xcworkspace -scheme GrandCentralBoard -sdk appletvsimulator9.2 -configuration 'Debug' ONLY_ACTIVE_ARCH=NO | xcpretty -c -f `xcpretty-travis-formatter`; exit ${PIPESTATUS[0]}
 }
 
 if [[ "$TRAVIS_PULL_REQUEST" != "false" ]] || [[ "$TRAVIS_BRANCH" == "mvp" ]]; then


### PR DESCRIPTION
This PR fixes CI integrations. 

The previous integration didn't work because of the xcpretty. Initially I thought that this was due to the `xcodebuild` - which in the past always returned 0 - but it turned out that by default xcpretty doesn't exit with the same status code as xcodebuild does. 

In order to make things work on Travis xcpretty is called together with [some extra additions](https://github.com/supermarin/xcpretty#usage).