### PR TITLE
Feature/gcb 350 header visibility setting

### DIFF
--- a/GrandCentralBoard/Widgets/Image/ImageWidget.swift
+++ b/GrandCentralBoard/Widgets/Image/ImageWidget.swift
@@ -11,10 +11,12 @@ final class ImageWidget: WidgetControlling {
 
     let widgetView: ImageWidgetView
     let sources: [UpdatingSource]
+    let isHeaderVisible: Bool
 
-    init(view: ImageWidgetView, sources: [UpdatingSource]) {
+    init(view: ImageWidgetView, sources: [UpdatingSource], isHeaderVisible: Bool) {
         self.widgetView = view
         self.sources = sources
+        self.isHeaderVisible = isHeaderVisible
     }
 
     var view: UIView {

--- a/GrandCentralBoard/Widgets/Image/ImageWidgetBuilder.swift
+++ b/GrandCentralBoard/Widgets/Image/ImageWidgetBuilder.swift
@@ -22,6 +22,9 @@ final class ImageWidgetBuilder: WidgetBuilding {
 
         let imagesSource = try RemoteImageSource(paths: settings.imagePaths, dataDownloader: dataDownloader)
         let view = ImageWidgetView.fromNib()
-        return ImageWidget(view: view, sources: [imagesSource])
+
+        return ImageWidget(view: view,
+                           sources: [imagesSource],
+                           isHeaderVisible: settings.isHeaderVisible ?? true)
     }
 }

--- a/GrandCentralBoard/Widgets/Image/ImageWidgetConfiguration.swift
+++ b/GrandCentralBoard/Widgets/Image/ImageWidgetConfiguration.swift
@@ -10,10 +10,14 @@ import Decodable
 
 struct ImageWidgetConfiguration {
     let imagePaths: [String]
+    let isHeaderVisible: Bool?
 }
 
 extension ImageWidgetConfiguration: Decodable {
     static func decode(json: AnyObject) throws -> ImageWidgetConfiguration {
-        return try ImageWidgetConfiguration(imagePaths: json => "urls")
+        return try ImageWidgetConfiguration(
+            imagePaths: json => "urls",
+            isHeaderVisible: json =>? "isHeaderVisible"
+        )
     }
 }


### PR DESCRIPTION
The default for `isHeaderVisible` is `true` if not set in configuration file.

Make sure these boxes are checked before submitting your Pull Request - thank you!

- [x] [SwiftLint](https://github.com/Realm/SwiftLint) is installed on your system
- [x] The project does not generate any warnings or errors
- [x] The tests are passing
- [x] Branch name is in line with [GitFlow](http://jeffkreeftmeijer.com/2010/why-arent-you-using-git-flow/)
