### PR TITLE
Feature/ignore disabled repositories

### DIFF
--- a/GrandCentralBoard/Widgets/GitHub/GitHubDataProvider.swift
+++ b/GrandCentralBoard/Widgets/GitHub/GitHubDataProvider.swift
@@ -49,7 +49,7 @@ final class GitHubDataProvider: GitHubDataProviding {
     }
 
     private func requestPullRequestsCountForRepository(repo: Repository) -> Observable<Repository> {
-        if repo.openIssuesCount == 0 {
+        guard repo.openIssuesCount > 0 else {
             return Observable.just(repo.repositoryWithPRCount(0))
         }
 

--- a/GrandCentralBoard/Widgets/GitHub/GitHubDataProvider.swift
+++ b/GrandCentralBoard/Widgets/GitHub/GitHubDataProvider.swift
@@ -49,6 +49,10 @@ final class GitHubDataProvider: GitHubDataProviding {
     }
 
     private func requestPullRequestsCountForRepository(repo: Repository) -> Observable<Repository> {
+        if repo.openIssuesCount == 0 {
+            return Observable.just(repo.repositoryWithPRCount(0))
+        }
+
         return moyaProvider.request(.PullRequests(repositoryFullName: repo.fullName)).mapJSON().map({ (object: AnyObject) -> Repository in
             guard let array = object as? NSArray else {
                 assertionFailure("Object is not an array")

--- a/GrandCentralBoardTests/Widgets/GitHub/GitHubDataProviderTests.swift
+++ b/GrandCentralBoardTests/Widgets/GitHub/GitHubDataProviderTests.swift
@@ -75,7 +75,11 @@ final class GitHubDataProviderTests: XCTestCase {
             expect(repo.fullName) == fullName
             expect(repo.name) == jsonReposArray[index]["name"] as? String
             expect(repo.openIssuesCount) == jsonReposArray[index]["open_issues_count"] as? Int
-            expect(repo.pullRequestsCount) == pullRequestsArray.count
+            if repo.openIssuesCount == 0 {
+                expect(repo.pullRequestsCount) == 0
+            } else {
+                expect(repo.pullRequestsCount) == pullRequestsArray.count
+            }
         }
     }
 


### PR DESCRIPTION
This PR provides:
- if a repository has 0 `open_issues_count` (this is a sum of PRs and issues on GitHub), then open PRs count is for sure 0, so no request to fetch PRs will be made. Thus saving some time when updating the view. Also deals nicely with disabled repos.

Make sure these boxes are checked before submitting your Pull Request - thank you!

- [ ] [SwiftLint](https://github.com/Realm/SwiftLint) is installed on your system
- [ ] The project does not generate any warnings or errors
- [ ] The tests are passing
- [ ] Branch name is in line with [GitFlow](http://jeffkreeftmeijer.com/2010/why-arent-you-using-git-flow/)
